### PR TITLE
fix: make sure that kernel images are found by sdboot correctly

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -85,7 +85,7 @@ _package() {
   install -Dm644 "$(make -s image_name)" "$modulesdir/vmlinuz"
 
   # Used by mkinitcpio to name the kernel
-  echo "$_base-{arch[1]}" | install -Dm644 /dev/stdin "$modulesdir/pkgbase"
+  echo "$_base-${arch[1]}" | install -Dm644 /dev/stdin "$modulesdir/pkgbase"
 
   echo "Installing modules..."
   make INSTALL_MOD_PATH="$pkgdir/usr" INSTALL_MOD_STRIP=1 modules_install

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,6 +7,7 @@ pkgver=5.12.968912.044a48f420b9
 _product="${pkgbase%-git}"
 _kernel_rel=5.12
 _branch=drm-next-${_kernel_rel}
+_base="${pkgbase//-/_}"
 pkgrel=1
 arch=(x86_64)
 url='https://gitlab.freedesktop.org/drm/amd'
@@ -41,7 +42,7 @@ prepare() {
   echo "Setting version..."
   scripts/setlocalversion --save-scmversion
   echo "-$pkgrel" > localversion.10-pkgrel
-  echo "${pkgbase#linux}" > localversion.20-pkgname
+  echo "${_base#linux}" > localversion.20-pkgname
 
   local src
   for src in "${source[@]}"; do
@@ -84,7 +85,7 @@ _package() {
   install -Dm644 "$(make -s image_name)" "$modulesdir/vmlinuz"
 
   # Used by mkinitcpio to name the kernel
-  echo "$pkgbase" | install -Dm644 /dev/stdin "$modulesdir/pkgbase"
+  echo "$_base-{arch[1]}" | install -Dm644 /dev/stdin "$modulesdir/pkgbase"
 
   echo "Installing modules..."
   make INSTALL_MOD_PATH="$pkgdir/usr" INSTALL_MOD_STRIP=1 modules_install


### PR DESCRIPTION
Fixes the kernel image naming so they could be found by the sdboot-manage and correct loader entries are created.